### PR TITLE
Add devcontainer setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/rust
+{
+    "name": "Rust",
+    // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+    "image": "mcr.microsoft.com/devcontainers/rust:2-1-trixie",
+
+    // Use 'mounts' to make the cargo cache persistent in a Docker Volume.
+    "mounts": [
+        {
+            "source": "devcontainer-cargo-cache-${devcontainerId}",
+            "target": "/usr/local/cargo",
+            "type": "volume"
+        }
+    ],
+
+    // Features to add to the dev container. More info: https://containers.dev/features.
+    // "features": {},
+
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [],
+
+    // Use 'postCreateCommand' to run commands after the container is created.
+    "postCreateCommand": ".devcontainer/post-create"
+
+    // Configure tool-specific properties.
+    // "customizations": {},
+
+    // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+    // "remoteUser": "root"
+}

--- a/.devcontainer/post-create
+++ b/.devcontainer/post-create
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -eux
+
+install_cargo_binstall() {
+    if ! command -v cargo-binstall &>/dev/null; then
+        curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+    fi
+}
+
+install_cargo_tool() {
+    local package="$1"
+    local binary="${2:-$package}"
+
+    if ! command -v "$binary" &>/dev/null; then
+        cargo binstall "$package" --no-confirm
+    fi
+}
+
+main() {
+    .github/ci-scripts/setup-build-ubuntu
+
+    rustup component add llvm-tools
+
+    rustup toolchain add nightly
+
+    rustc --version
+    rustc +nightly --version
+
+    install_cargo_binstall
+    install_cargo_tool just
+    install_cargo_tool cargo-hack
+    install_cargo_tool cargo-docs-rs
+    install_cargo_tool cargo-sync-rdme
+    install_cargo_tool cargo-machete
+    install_cargo_tool cargo-llvm-cov
+    install_cargo_tool cargo-deny
+}
+
+main "$@"

--- a/.github/ci-scripts/setup-build-ubuntu
+++ b/.github/ci-scripts/setup-build-ubuntu
@@ -9,3 +9,6 @@ sudo apt-get install -y libtesseract-dev libleptonica-dev pkg-config
 
 # ffmpeg-next
 sudo apt-get install -y clang libavcodec-dev libavformat-dev libavutil-dev libswscale-dev pkg-config
+
+# sdl2
+sudo apt-get install -y cmake


### PR DESCRIPTION
## Summary
- add a Rust devcontainer configuration for local development
- install CI-required Rust tools and toolchains in the devcontainer post-create step
- reuse the Ubuntu build setup script and add `cmake` for SDL2 builds

## Testing
- `just ci` in the devcontainer