### PR TITLE
Update cargo-deny configuration

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -70,6 +70,7 @@ feature-depth = 1
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
+    { id = "RUSTSEC-2024-0436", reason = "waiting on a fix to be released" },
     #"RUSTSEC-0000-0000",
     #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
     #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
@@ -96,6 +97,7 @@ allow = [
     "BSL-1.0",
     "ISC",
     "WTFPL",
+    "Zlib",
     #"Apache-2.0 WITH LLVM-exception",
 ]
 # The confidence threshold for detecting a license from license text.


### PR DESCRIPTION
## Summary
- ignore advisory `RUSTSEC-2024-0436` with a reason
- allow the `Zlib` license in `deny.toml`

## Validation
- `cargo deny check advisories licenses bans sources`
