### PR TITLE
Run sync-rdme job on stable toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        rust: [nightly]
+        rust: [stable]
         os: ${{ fromJSON(needs.set-matrix.outputs.os) }}
     runs-on: ${{ matrix.os }}
     steps:
@@ -180,6 +180,8 @@ jobs:
         with:
           tool: just,cargo-hack,cargo-sync-rdme
       - uses: Swatinem/rust-cache@v2
+      - run: rustup toolchain install nightly --profile minimal
+        shell: bash
       - run: just ci-sync-rdme
         shell: bash
 


### PR DESCRIPTION
## Summary
- run the Sync Readme workflow job with the stable Rust toolchain
- install nightly separately for cargo-sync-rdme